### PR TITLE
Adds support for accessible labels

### DIFF
--- a/examples/icon/app.js
+++ b/examples/icon/app.js
@@ -22,6 +22,10 @@ const colorExample = (
   <SocialIcon network="twitter" color="#ff5a01" />
 );
 
+const labelExample = (
+  <SocialIcon url="https://www.example.com" label="Our portfolio" />
+);
+
 const urls = [
   'http://jaketrent.com',
   'http://twitter.com/jaketrent',
@@ -51,6 +55,7 @@ ReactDOM.render(lib, document.getElementById('lib'));
 ReactDOM.render(networkExample, document.getElementById('network-example'));
 ReactDOM.render(urlExample, document.getElementById('url-example'));
 ReactDOM.render(colorExample, document.getElementById('color-example'));
+ReactDOM.render(labelExample, document.getElementById('label-example'));
 ReactDOM.render(iconsExample, document.getElementById('icons-example'));
 ReactDOM.render(iconsColorExample, document.getElementById('icons-color-example'));
 ReactDOM.render(sizes, document.getElementById('sizes'));

--- a/examples/index.html
+++ b/examples/index.html
@@ -54,6 +54,17 @@
       </code>
     </div>
 
+    <h4>Specify the Label</h4>
+    <p>
+      By default, the <code>SocialIcon</code> will use the name of a social network as an icon's accessible label. If you think the social network name is not enough context, you can pass in the <code>label</code> prop.
+    </p>
+    <div class="one-line-example">
+      <div class="icon" id="label-example"></div>
+      <code class="code">
+            <pre>&lt;SocialIcon url="https://www.example.com" label="Our portfolio" /&gt;</pre>
+          </code>
+    </div>
+
     <h4>Render</h4>
     <p>The full code required to render.</p>
     <code class="code">

--- a/src/social-icon.js
+++ b/src/social-icon.js
@@ -21,7 +21,7 @@ function SocialIcon(props) {
        rel="noopener"
        className={cx('social-icon', className)}
        style={{ ...socialIcon, ...props.style }}
-       aria-label={label}>
+       aria-label={label || networkKey}>
       <div className="social-container" style={socialContainer} >
         <svg className="social-svg" style={socialSvg} viewBox="0 0 64 64">
           <Background />

--- a/src/social-icon.js
+++ b/src/social-icon.js
@@ -11,7 +11,7 @@ function getNetworkKey(props) {
 }
 
 function SocialIcon(props) {
-  const { url, network, color, className, ...rest } = props;
+  const { url, network, color, className, label, ...rest } = props;
   const networkKey = getNetworkKey({ url, network });
 
   return (
@@ -20,7 +20,8 @@ function SocialIcon(props) {
        target="_blank"
        rel="noopener"
        className={cx('social-icon', className)}
-       style={{ ...socialIcon, ...props.style }}>
+       style={{ ...socialIcon, ...props.style }}
+       aria-label={label}>
       <div className="social-container" style={socialContainer} >
         <svg className="social-svg" style={socialSvg} viewBox="0 0 64 64">
           <Background />
@@ -35,6 +36,7 @@ function SocialIcon(props) {
 SocialIcon.propTypes = {
   className: PropTypes.string,
   color: PropTypes.string,
+  label: PropTypes.string,
   network: PropTypes.string,
   url: PropTypes.string,
 };


### PR DESCRIPTION
## Tasks
- [x] Add support for `label` on `SocialIcon` component.
- [ ] Add support for `label` on `SocialIcons` component.
- [ ] Document change(s) to API.
## Summary
Per #26, the components in this lib should expose accessible labels for the links they generate. This PR adds a `label` prop to the `SocialIcon`, which applies an `aria-label` to the link generated by the component. Example:
``` js
<SocialIcon url="https://twitter.com/apple" label="Follow Apple on Twitter!"/>
```
## Blocking concerns
What's the best way to add `label` support to the `SocialIcons` convenience component? It seems to me that the `urls` prop that `SocialIcons` currently takes should become an array of _objects_ with shape `{ url: String label: String }`. This would mean that the `urls` array is not really an array of URLs anymore, which means that prop might need to be renamed, which is complicated. Happy to take direction on this and implement whatever the maintainers prefer!