### PR TITLE
Render div instead of anchor when no url prop is provided

### DIFF
--- a/src/social-icon.js
+++ b/src/social-icon.js
@@ -15,6 +15,27 @@ function SocialIcon(props) {
   const { url, network, bgColor, fgColor, className, label, ...rest } = props
   const networkKey = getNetworkKey({ url, network })
 
+  const icon = (
+    <div className="social-container" style={socialContainer}>
+      <svg className="social-svg" style={socialSvg} viewBox="0 0 64 64">
+        <Background />
+        <Icon networkKey={networkKey} fgColor={fgColor} />
+        <Mask networkKey={networkKey} bgColor={bgColor} />
+      </svg>
+    </div>
+  )
+
+  if (!url) {
+    return <div 
+      {...rest}
+      className={'social-icon' + (!!className ? ' ' + className : '')}
+      style={{ ...socialIcon, ...props.style }}
+      aria-label={label || networkKey}
+    >
+      {icon}
+    </div>
+  }
+
   return (
     <a
       {...rest}
@@ -23,13 +44,7 @@ function SocialIcon(props) {
       style={{ ...socialIcon, ...props.style }}
       aria-label={label || networkKey}
     >
-      <div className="social-container" style={socialContainer}>
-        <svg className="social-svg" style={socialSvg} viewBox="0 0 64 64">
-          <Background />
-          <Icon networkKey={networkKey} fgColor={fgColor} />
-          <Mask networkKey={networkKey} bgColor={bgColor} />
-        </svg>
-      </div>
+      {icon}
     </a>
   )
 }

--- a/src/social-icon.js
+++ b/src/social-icon.js
@@ -15,6 +15,12 @@ function SocialIcon(props) {
   const { url, network, bgColor, fgColor, className, label, ...rest } = props
   const networkKey = getNetworkKey({ url, network })
 
+  const outerProps = {
+    className: 'social-icon' + (!!className ? ' ' + className : ''),
+    style: { ...socialIcon, ...props.style },
+    'aria-label': label || networkKey
+  }
+
   const icon = (
     <div className="social-container" style={socialContainer}>
       <svg className="social-svg" style={socialSvg} viewBox="0 0 64 64">
@@ -28,9 +34,7 @@ function SocialIcon(props) {
   if (!url) {
     return <div 
       {...rest}
-      className={'social-icon' + (!!className ? ' ' + className : '')}
-      style={{ ...socialIcon, ...props.style }}
-      aria-label={label || networkKey}
+      {...outerProps}
     >
       {icon}
     </div>
@@ -39,10 +43,8 @@ function SocialIcon(props) {
   return (
     <a
       {...rest}
+      {...outerProps}
       href={url}
-      className={'social-icon' + (!!className ? ' ' + className : '')}
-      style={{ ...socialIcon, ...props.style }}
-      aria-label={label || networkKey}
     >
       {icon}
     </a>

--- a/test/social-icon.spec.js
+++ b/test/social-icon.spec.js
@@ -5,99 +5,172 @@ import Mask from '../src/mask'
 import SocialIcon from '../src/social-icon'
 import Background from '../src/background'
 import { shallow } from 'enzyme'
+import should from 'should'
 
 describe('<SocialIcon />', () => {
-  const url = 'http://pinterest.com'
-  let socialIcon
-  beforeEach(() => {
-    socialIcon = shallow(<SocialIcon url={url} />)
+  describe('with url', () => {
+    const url = 'http://pinterest.com'
+    let socialIcon
+    beforeEach(() => {
+      socialIcon = shallow(<SocialIcon url={url} />)
+    })
+  
+    it('takes a url prop', () => {
+      socialIcon.props().href.should.eql(url)
+    })
+  
+    it('renders the anchor with the url', () => {
+      const a = socialIcon.find('a')
+      a.length.should.eql(1)
+      a.hasClass('social-icon').should.eql(true)
+      a.props().href.should.eql(url)
+    })
+  
+    it('doesnt have a target prop', () => {
+      const a = socialIcon.find('a')
+      a.props().should.not.have.property('target')
+      a.props().should.not.have.property('rel')
+    })
+  
+    it('can add a target prop', () => {
+      const a = shallow(
+        <SocialIcon url={url} target="_blank" rel="noopener noreferrer" />
+      ).find('a')
+      a.props().target.should.eql('_blank')
+      a.props().rel.should.eql('noopener noreferrer')
+    })
+  
+    it('renders the container', () => {
+      socialIcon.find('.social-container').length.should.eql(1)
+    })
+  
+    it('renders the display svg', () => {
+      socialIcon.find('.social-svg').length.should.eql(1)
+    })
+  
+    it('renders a circle for the background', () => {
+      socialIcon.find('social-svg-background').length.should.eql(0)
+      socialIcon.find(Background).length.should.eql(1)
+      socialIcon
+        .find(Background)
+        .shallow()
+        .find('circle')
+        .length.should.eql(1)
+    })
+  
+    it('renders an icon based on the url', () => {
+      const path = socialIcon
+        .find(Icon)
+        .shallow()
+        .find('path')
+      path.prop('d').should.eql(iconFor('pinterest'))
+    })
+  
+    it('renders a mask based on the url', () => {
+      const mask = socialIcon
+        .find(Mask)
+        .shallow()
+        .find('path')
+      mask.prop('d').should.eql(maskFor('pinterest'))
+    })
+  
+    it('takes a network prop for overriding default generated from url', () => {
+      socialIcon = shallow(<SocialIcon url={url} network="github" />)
+      const mask = socialIcon
+        .find(Mask)
+        .shallow()
+        .find('path')
+      mask.prop('d').should.eql(maskFor('github'))
+    })
+  
+    it('takes a bgColor prop for overriding default bgColor', () => {
+      const bgColor = 'pink'
+      socialIcon = shallow(<SocialIcon bgColor={bgColor} network="github" />)
+      const mask = socialIcon
+        .find(Mask)
+        .shallow()
+        .find('.social-svg-mask')
+      mask.prop('style').fill.should.eql(bgColor)
+    })
+  
+    it('takes a fgColor prop for overriding default transparent fgColor', () => {
+      const fgColor = 'red'
+      socialIcon = shallow(<SocialIcon fgColor={fgColor} network="github" />)
+      const icon = socialIcon
+        .find(Icon)
+        .shallow()
+        .find('.social-svg-icon')
+      icon.prop('style').fill.should.eql(fgColor)
+    })
   })
 
-  it('takes a url prop', () => {
-    socialIcon.props().href.should.eql(url)
-  })
-
-  it('renders the anchor with the url', () => {
-    const a = socialIcon.find('a')
-    a.length.should.eql(1)
-    a.hasClass('social-icon').should.eql(true)
-    a.props().href.should.eql(url)
-  })
-
-  it('doesnt have a target prop', () => {
-    const a = socialIcon.find('a')
-    a.props().should.not.have.property('target')
-    a.props().should.not.have.property('rel')
-  })
-
-  it('can add a target prop', () => {
-    const a = shallow(
-      <SocialIcon url={url} target="_blank" rel="noopener noreferrer" />
-    ).find('a')
-    a.props().target.should.eql('_blank')
-    a.props().rel.should.eql('noopener noreferrer')
-  })
-
-  it('renders the container', () => {
-    socialIcon.find('.social-container').length.should.eql(1)
-  })
-
-  it('renders the display svg', () => {
-    socialIcon.find('.social-svg').length.should.eql(1)
-  })
-
-  it('renders a circle for the background', () => {
-    socialIcon.find('social-svg-background').length.should.eql(0)
-    socialIcon.find(Background).length.should.eql(1)
-    socialIcon
-      .find(Background)
-      .shallow()
-      .find('circle')
-      .length.should.eql(1)
-  })
-
-  it('renders an icon based on the url', () => {
-    const path = socialIcon
-      .find(Icon)
-      .shallow()
-      .find('path')
-    path.prop('d').should.eql(iconFor('pinterest'))
-  })
-
-  it('renders a mask based on the url', () => {
-    const mask = socialIcon
-      .find(Mask)
-      .shallow()
-      .find('path')
-    mask.prop('d').should.eql(maskFor('pinterest'))
-  })
-
-  it('takes a network prop for overriding default generated from url', () => {
-    socialIcon = shallow(<SocialIcon url={url} network="github" />)
-    const mask = socialIcon
-      .find(Mask)
-      .shallow()
-      .find('path')
-    mask.prop('d').should.eql(maskFor('github'))
-  })
-
-  it('takes a bgColor prop for overriding default bgColor', () => {
-    const bgColor = 'pink'
-    socialIcon = shallow(<SocialIcon bgColor={bgColor} network="github" />)
-    const mask = socialIcon
-      .find(Mask)
-      .shallow()
-      .find('.social-svg-mask')
-    mask.prop('style').fill.should.eql(bgColor)
-  })
-
-  it('takes a fgColor prop for overriding default transparent fgColor', () => {
-    const fgColor = 'red'
-    socialIcon = shallow(<SocialIcon fgColor={fgColor} network="github" />)
-    const icon = socialIcon
-      .find(Icon)
-      .shallow()
-      .find('.social-svg-icon')
-    icon.prop('style').fill.should.eql(fgColor)
+  describe('without url', () => {
+    const network = 'pinterest'
+    let socialIcon
+    beforeEach(() => {
+      socialIcon = shallow(<SocialIcon network={network} />)
+    })
+  
+    it('no url prop', () => {
+      should.not.exist(socialIcon.props().href)
+    })
+  
+    it('renders the div with the network', () => {
+      socialIcon.is('[aria-label="pinterest"]').should.eql(true)
+    })
+  
+    it('renders the container', () => {
+      socialIcon.find('.social-container').length.should.eql(1)
+    })
+  
+    it('renders the display svg', () => {
+      socialIcon.find('.social-svg').length.should.eql(1)
+    })
+  
+    it('renders a circle for the background', () => {
+      socialIcon.find('social-svg-background').length.should.eql(0)
+      socialIcon.find(Background).length.should.eql(1)
+      socialIcon
+        .find(Background)
+        .shallow()
+        .find('circle')
+        .length.should.eql(1)
+    })
+  
+    it('renders an icon based on the url', () => {
+      const path = socialIcon
+        .find(Icon)
+        .shallow()
+        .find('path')
+      path.prop('d').should.eql(iconFor('pinterest'))
+    })
+  
+    it('renders a mask based on the url', () => {
+      const mask = socialIcon
+        .find(Mask)
+        .shallow()
+        .find('path')
+      mask.prop('d').should.eql(maskFor('pinterest'))
+    })
+  
+    it('takes a bgColor prop for overriding default bgColor', () => {
+      const bgColor = 'pink'
+      socialIcon = shallow(<SocialIcon bgColor={bgColor} network="github" />)
+      const mask = socialIcon
+        .find(Mask)
+        .shallow()
+        .find('.social-svg-mask')
+      mask.prop('style').fill.should.eql(bgColor)
+    })
+  
+    it('takes a fgColor prop for overriding default transparent fgColor', () => {
+      const fgColor = 'red'
+      socialIcon = shallow(<SocialIcon fgColor={fgColor} network="github" />)
+      const icon = socialIcon
+        .find(Icon)
+        .shallow()
+        .find('.social-svg-icon')
+      icon.prop('style').fill.should.eql(fgColor)
+    })
   })
 })


### PR DESCRIPTION
This library is beautiful, so there is a use case where someone may want to add a label or message beside the icon, and make the whole region a link. For instance:

![image](https://user-images.githubusercontent.com/8896153/56839371-15a5d880-687a-11e9-8500-96a9553f066e.png)


Unfortunately this would result in the following warning:

```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
```

Rather than try to accept children or anything which may limit flexibility, I propose simply not rendering an `<a />` tag when no url is provided, as the component already behaves gracefully in this scenario.

### Things that will need doing:

- [x] Update component
- [x] Add tests
- [ ] Update docs


### Visual testing:

```js
// Add this to examples/app.js to render alternate icons with a url
// This proves that the style of the div vs a is equivalent
const lib = h(
  'div',
  {},
  networks.KEYS.map((k, i) => h(SocialIcon, { url: i % 2 === 0 ? 'https://linkedin.com/in/jaketrent' : undefined, network: k, title: k, key: k }))
)
```

![image](https://user-images.githubusercontent.com/8896153/56839414-4ede4880-687a-11e9-9081-ef2973e88c2d.png)
